### PR TITLE
add 'auto_create' option for config file, default True

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,5 +5,9 @@
   directory? The default option of putting it in a sub-folder of the project is
   useful for projects that need to store extra data, but may be overkill for
   basic projects.
-- add an Option to not include the `schema_version` key. By default this key
+- Add Option to look for the config file in the current directory, and if not found
+  then look in the users home directory. This would allow for a project to
+  override the users config file.
+- Add option to disable auto-creating the config file if it doesn't exist.
+- Add an Option to not include the `schema_version` key. By default this key
   **will** be included.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,9 +10,9 @@ A Python library to save your settings in a TOML file.
 
 !!! danger "Development software"
 
-    Note that this library is still in the early stages of development and may
-    contain bugs and/or change in the future.  Please report any bugs you find
-    on the [issue tracker](https://github.com/seapagan/simple-toml-settings/issues){:target="_blank"}
+    Note that this library is still in the development and may contain bugs
+    and/or change in the future. Please report any bugs you find on the
+    [issue tracker](https://github.com/seapagan/simple-toml-settings/issues){:target="_blank"}
     and feel free to make suggestions for improvements.
 
 ---
@@ -36,9 +36,11 @@ class MySettings(TOMLSettings):
 settings = MySettings("test_app")
 ```
 
-The above will automatically create a TOML file in the user's home directory
-called `config.toml` and save the settings to it. If the file already exists,
-the settings will be loaded from it.
+The above will automatically create a `Folder` in the user home directory called
+`.test_app`, a configuration file in this called 'config.toml` and then save the
+default settings to it.
+
+However, if the file already exists, the settings will be loaded from it.
 
 The file contents for the above example would be:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -135,6 +135,26 @@ settings.save()
     created and when the `set` method is called respectively.  You should not
     need to call `load()` manually.
 
+## Options
+
+There are a couple of options you can pass to the `TOMLSettings` constructor to
+change the behaviour of the class:
+
+### `settings_file_name`
+
+This is the name of the settings file to use.  By default this is set to
+`config.toml`.
+
+### `auto_create`
+
+This defaults to `True` and will automatically create the settings file if it
+does not exist and fill it with the default values.  If set to `False`, the
+class will raise an exception
+(**`simple_toml_settings.exceptions.SettingsNotFound`**) if the settings file does
+not exist. You can catch this exception and handle it as you wish.
+*The folder will be created anyway if it does not exist, as the assumption is
+that you will want to save the settings at some point*.
+
 ## Post-create hook
 
 If you need to do some further processing, or set some input from the user after

--- a/simple_toml_settings/exceptions.py
+++ b/simple_toml_settings/exceptions.py
@@ -1,0 +1,17 @@
+"""Define exceptions for the simple_toml_settings package."""
+
+
+class SettingsError(Exception):
+    """Base exception for settings errors."""
+
+    pass
+
+
+class SettingsNotFound(SettingsError):
+    """The Settings file has not been found.
+
+    This will be raised if the settings file is not found and auto_create is
+    False.
+    """
+
+    pass

--- a/simple_toml_settings/settings.py
+++ b/simple_toml_settings/settings.py
@@ -23,6 +23,7 @@ class TOMLSettings:
 
     app_name: str
     settings_file_name: str = "config.toml"
+    auto_create: bool = True
 
     # the schema_version is used to track changes to the settings file.
     schema_version: str = "none"
@@ -32,6 +33,7 @@ class TOMLSettings:
             "app_name",
             "settings_folder",
             "settings_file_name",
+            "auto_create",
         }
     )
 
@@ -80,7 +82,8 @@ class TOMLSettings:
             )
         except FileNotFoundError:
             self.__post_create_hook__()
-            self.save()
+            if self.auto_create:
+                self.save()
             return
 
         for key, value in settings[self.app_name].items():

--- a/simple_toml_settings/settings.py
+++ b/simple_toml_settings/settings.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, Set
 
 import rtoml
 
+from simple_toml_settings.exceptions import SettingsNotFound
+
 
 @dataclass
 class TOMLSettings:
@@ -80,10 +82,12 @@ class TOMLSettings:
             settings = rtoml.load(
                 self.settings_folder / self.settings_file_name
             )
-        except FileNotFoundError:
-            self.__post_create_hook__()
+        except FileNotFoundError as exc:
             if self.auto_create:
+                self.__post_create_hook__()
                 self.save()
+            else:
+                raise SettingsNotFound from exc
             return
 
         for key, value in settings[self.app_name].items():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,9 @@
 """Test the settings module."""
 from pathlib import Path
 
+import pytest
+
+from simple_toml_settings.exceptions import SettingsNotFound
 from simple_toml_settings.settings import TOMLSettings
 
 
@@ -11,12 +14,12 @@ def test_config_file_auto_created(settings):
     assert settings.settings_file_name == "config.toml"
 
 
-def test_config_file_not_created_if_auto_create_is_false(fs):
+def test_exception_raised_on_missing_config_if_auto_create_is_false(fs):
     """Test that the settings file is not created if auto_create is False."""
     fs.create_dir(Path.home())
-    settings = TOMLSettings("test_app", auto_create=False)
 
-    assert not (settings.settings_folder / settings.settings_file_name).exists()
+    with pytest.raises(SettingsNotFound):
+        TOMLSettings("test_app", auto_create=False)
 
 
 def test_post_create_hook_is_called(fs, mocker):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,6 +11,14 @@ def test_config_file_auto_created(settings):
     assert settings.settings_file_name == "config.toml"
 
 
+def test_config_file_not_created_if_auto_create_is_false(fs):
+    """Test that the settings file is not created if auto_create is False."""
+    fs.create_dir(Path.home())
+    settings = TOMLSettings("test_app", auto_create=False)
+
+    assert not (settings.settings_folder / settings.settings_file_name).exists()
+
+
 def test_post_create_hook_is_called(fs, mocker):
     """Test that the post_create_hook is called after settings file created."""
     fs.create_dir(Path.home())


### PR DESCRIPTION
Whether we automatically create a missing config file or not. Defaults to True. The '__post_create_hook__()` will also not be run.

Exception raised if the file is missing.