### PR TITLE
implement a `flat_config` option. 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,6 @@
 # Future Plans
 
 - Allow a custom folder root (not just users $HOME) folder.
-- Add an option to just store the config file in the users home directory. The
-  default option of putting it in a sub-folder of the project is useful for
-  projects that need to store extra data, but may be overkill for basic
-  projects.
 - Add an Option to look for the config file in the current directory, and if not
   found then look in the users home directory.
 - Add an Option to not include the `schema_version` key. By default this key

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -231,6 +231,12 @@ This defaults to `False` and will cause the settings file to be saved/read from
 the current directory instead of the user's home directory.  This is good for
 utility apps that need different settings for different projects / filelists.
 
+### `flat_config`
+
+This defaults to `False` and will cause the settings file to be created and read
+from the users home directory, but without the subfolder.  Use this when
+creating an extra folder in the user's home directory is overkill.
+
 ## Post-create hook
 
 If you need to do some further processing, or set some input from the user after

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ convention = "google"
 "tests/**/*.py" = [
   "S101",   # we can (and MUST!) use 'assert' in test files.
   "ANN001", # annotations for fixtures are sometimes a pain for test files
+  "ARG00",  # test fixtures often are not directly used
 ]
 
 

--- a/simple_toml_settings/settings.py
+++ b/simple_toml_settings/settings.py
@@ -33,6 +33,7 @@ class TOMLSettings:
     settings_file_name: str = "config.toml"
     auto_create: bool = True
     local_file: bool = False
+    flat_config: bool = False
 
     # the schema_version is used to track changes to the settings file.
     schema_version: str = "none"
@@ -47,19 +48,33 @@ class TOMLSettings:
             "settings_file_name",
             "auto_create",
             "local_file",
+            "flat_config",
         }
     )
 
     def __post_init__(self) -> None:
         """Create the settings folder if it doesn't exist."""
-        if not self.local_file:
-            self.settings_folder: Path = Path.home() / f".{self.app_name}"
-            if not self.settings_folder.exists():
-                self.settings_folder.mkdir(parents=False)
-        else:
-            self.settings_folder = Path.cwd()
+        self.settings_folder = self.get_settings_folder()
 
         self.load()
+
+    def get_settings_folder(self) -> Path:
+        """Return the settings folder. If it doesn't exist, create it.
+
+        Take into account the `local_file` and `flat_config` settings.
+        """
+        if self.local_file:
+            return Path.cwd()
+
+        settings_folder: Path = (
+            Path.home() / f".{self.app_name}"
+            if not self.flat_config
+            else Path.home()
+        )
+        if not settings_folder.exists():
+            settings_folder.mkdir(parents=False)
+
+        return settings_folder
 
     def __post_create_hook__(self) -> None:
         """Allow further customization after a new settings file is created.

--- a/simple_toml_settings/settings.py
+++ b/simple_toml_settings/settings.py
@@ -62,15 +62,15 @@ class TOMLSettings:
         """Return the settings folder. If it doesn't exist, create it.
 
         Take into account the `local_file` and `flat_config` settings.
+        Note that `local_file` takes precedence over `flat_config`.
         """
         if self.local_file:
             return Path.cwd()
 
-        settings_folder: Path = (
-            Path.home() / f".{self.app_name}"
-            if not self.flat_config
-            else Path.home()
-        )
+        if self.flat_config:
+            return Path.home()
+
+        settings_folder: Path = Path.home() / f".{self.app_name}"
         if not settings_folder.exists():
             settings_folder.mkdir(parents=False)
 
@@ -104,7 +104,7 @@ class TOMLSettings:
             cls._instances[cls] = cls(app_name, *args, **kwargs)
         return cast(T, cls._instances[cls])
 
-    def get_attrs(self, *, include_none: bool = False) -> dict[str, str]:
+    def get_attrs(self, *, include_none: bool = False) -> dict[str, Any]:
         """Return a dictionary of our setting values.
 
         Values that are None are EXCLUDED by default, but can be included by
@@ -165,7 +165,7 @@ class TOMLSettings:
     def set(
         self,
         key: str,
-        value: str,
+        value: Any,  # noqa: ANN401
         *,
         autosave: bool = True,
     ) -> None:
@@ -178,6 +178,6 @@ class TOMLSettings:
         if autosave:
             self.save()
 
-    def list_settings(self) -> dict[str, str]:
+    def list_settings(self) -> dict[str, Any]:
         """Return a dictionary of settings."""
         return self.get_attrs()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Configure pytest for the tests in this directory."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from simple_toml_settings.settings import TOMLSettings
+
+if TYPE_CHECKING:
+    from pyfakefs.fake_filesystem import FakeFilesystem
 
 
 class SettingsExample(TOMLSettings):
@@ -17,7 +21,7 @@ class SettingsExample(TOMLSettings):
 
 
 @pytest.fixture()
-def settings(fs) -> SettingsExample:
+def settings(fs: FakeFilesystem) -> SettingsExample:
     """Return a Settings object for testing.
 
     This fixture creates a fake home directory in a virtual filesystem. It then
@@ -29,3 +33,13 @@ def settings(fs) -> SettingsExample:
 
     # Create and return a Settings object for the test
     return SettingsExample("test_app")
+
+
+@pytest.fixture()
+def flat_settings(fs: FakeFilesystem) -> SettingsExample:
+    """Return a Settings object for testing with a flat config."""
+    # Create a fake home directory for the test
+    fs.create_dir(Path.home())
+
+    # Create and return a Settings object for the test
+    return SettingsExample("test_app", flat_config=True)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -61,6 +61,14 @@ schema_version= '1'
         assert settings.get("app_name") == "test_app"
         assert settings.get("test_string_var") == "local_app"
 
+    def test_flat_config(self, flat_settings: SettingsExample) -> None:
+        """Test that flat_config loads settings from home folder directly."""
+        assert flat_settings.get("app_name") == "test_app"
+        assert flat_settings.get("test_string_var") == "test_value"
+
+        assert flat_settings.settings_folder == Path.home()
+        assert Path(Path.home() / self.SETTINGS_FILE_NAME).exists()
+
     def test_post_create_hook_is_called(
         self, fs: FakeFilesystem, mocker: MockerFixture
     ) -> None:


### PR DESCRIPTION
If the `flat_config` option is set to `True` when instantiating the settings object, the config file is stored in the home folder directly, not in a subfolder. 

It defaults to `False`, so no code adjustments are needed if you do not plan to use this mode.