### PR TITLE
Relax some dependency version specs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2044,4 +2044,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "e721829259c10baf4dc7a7bdb3a9260f6c865b09f97e9c809698d9ba2e5cb97b"
+content-hash = "82863cfd9f01a2a0182b9d97ee0c110830edb4012f34c72cf61ced3d0c11da4a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-rtoml = "^0.9.0"
-github-changelog-md = "0.9.2"
+rtoml = ">=0.9.0,<1.0.0"
+github-changelog-md = ">=0.9.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Some of the needed deps had quite a tight vesrion range. Relaxing this as (eg) the newser versions or `rtoml` were not getting pulled.