### PR TITLE
disable coverage upload if token not set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,19 +58,12 @@ jobs:
       - name: Test with pytest
         run: |
           poetry run pytest --cov-report=xml
-      # - name: Upload coverage reports to Codecov
-      #   uses: codecov/codecov-action@v3
-      #   with:
-      #     file: ./coverage.xml
-      #     fail_ci_if_error: true
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     name: codecov-python-${{ matrix.python-version }}
       - name: Run codacy-coverage-reporter
+        env:
+          CODACY_CONFIGURED: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        if: ${{ env.CODACY_CONFIGURED != ''}}
         uses: codacy/codacy-coverage-reporter-action@v1
+        continue-on-error: true
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          # or
-          # api-token: ${{ secrets.CODACY_API_TOKEN }}
           coverage-reports: ./coverage.xml
-          # or a comma-separated list for multiple reports
-          # coverage-reports: <PATH_TO_REPORT>, <PATH_TO_REPORT>


### PR DESCRIPTION
On forks, the tests GH action will fail because the `codecov` token is probably not set and so cannot upload the stats. this disables that stage of the action if so.