### PR TITLE
Mark some options as mutually exclusive and raise exception if more than one used

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,9 @@ A Python library to save your settings in a TOML file.
 - Automatically create a folder in the user's home directory to store the
   settings, write directly to the home folder, or use the application's local
   directory.
+- Option to use the `XDG_CONFIG_HOME` environment variable to store the settings
+  in the `XDG` configuration directory, or default to `XDG` method of storing
+  configuration files in the `~/.config/<app_name` folder if this is not set.
 - By default the setting file is automatically created when the class is
   instantiated and the settings are saved to it. If the file already exists, the
   settings are loaded from it instead. This can be disabled if required.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -73,6 +73,17 @@ This is the preferred method and ensures that the settings class is a
     always the same but needs to be specified anyway. You still need to pass the
     parameters to the first instance to create it.
 
+    Best practice is to use a single function to get the instance and pass the
+    parameters to that function, so you only need to change the parameters in
+    one place if they change.
+
+    ```python
+    def get_settings():
+        return MySettings.get_instance("my_app_name")
+    ```
+
+    Then import `get_settings()` whenever it is needed.
+
 ## Settings file
 
 The above will automatically create a sub folder in the user's home directory
@@ -252,6 +263,12 @@ settings = MySettings("my_app_name", xdg_config=True)
 
 Assuming the `XDG_CONFIG_HOME` variable is not set, the settings file will be
 saved as `~/.config/my_app_name/config.toml`.
+
+!!! Danger "Mutually exclusive options"
+
+    The `local_file`, `flat_config` and `xdg_config` options are **mutually
+    exclusive**.  If more than one is `True`, a `SettingsMutuallyExclusiveError`
+    exception will be raised.
 
 ## Post-create hook
 

--- a/simple_toml_settings/exceptions.py
+++ b/simple_toml_settings/exceptions.py
@@ -26,5 +26,14 @@ class SettingsSchemaError(SettingsError):
         )
 
 
+class SettingsMutuallyExclusiveError(SettingsError):
+    """Two or more mutually exclusive settings are set to True."""
+
+    def __init__(self, attrs: set[str]) -> None:
+        """Define a custom response for this Exception."""
+        self.attrs = attrs
+        super().__init__(f"Only one of {', '.join(self.attrs)} can be True.")
+
+
 # temporary alias for backwards compatibility
 SettingsNotFound = SettingsNotFoundError

--- a/simple_toml_settings/settings.py
+++ b/simple_toml_settings/settings.py
@@ -18,8 +18,8 @@ from simple_toml_settings.exceptions import (
 )
 from simple_toml_settings.xdg_config import xdg_config_home
 
-SettingsT = TypeVar("SettingsT", bound="TOMLSettings")
-ExclusiveT = TypeVar("ExclusiveT", bound=str)
+T = TypeVar("T", bound="TOMLSettings")
+
 
 @dataclass
 class TOMLSettings:
@@ -56,7 +56,7 @@ class TOMLSettings:
         }
     )
 
-    _mutually_exclusive: set[ExclusiveT] = field(
+    _mutually_exclusive: set[str] = field(
         default_factory=lambda: {"local_file", "flat_config", "xdg_config"}
     )
 
@@ -108,11 +108,11 @@ class TOMLSettings:
 
     @classmethod
     def get_instance(
-        cls: type[SettingsT],
+        cls: type[T],
         app_name: str,
         *args: Any,  # noqa: ANN401
         **kwargs: Any,  # noqa: ANN401
-    ) -> SettingsT:
+    ) -> T:
         """Class method to get or create the Settings instance.
 
         This is optional (and experimental), and is provided to allow for a
@@ -121,7 +121,7 @@ class TOMLSettings:
         """
         if cls not in cls._instances:
             cls._instances[cls] = cls(app_name, *args, **kwargs)
-        return cast(SettingsT, cls._instances[cls])
+        return cast(T, cls._instances[cls])
 
     def get_attrs(self, *, include_none: bool = False) -> dict[str, Any]:
         """Return a dictionary of our setting values.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,6 +7,7 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_mock import MockerFixture
 
 from simple_toml_settings.exceptions import (
+    SettingsMutuallyExclusiveError,
     SettingsNotFoundError,
     SettingsSchemaError,
 )
@@ -303,3 +304,13 @@ schema_version= '1'
         fs.create_dir(Path.home())
         settings = CustomSettings.get_instance("test_app")
         assert settings.my_var is False
+
+    def test_mutually_exclusive_attributes(self, fs: FakeFilesystem) -> None:
+        """Test that mutually exclusive attributes are handled."""
+        fs.create_dir(Path.home())
+
+        with pytest.raises(
+            SettingsMutuallyExclusiveError,
+            match="Only one of flat_config, local_file can be True.",
+        ):
+            CustomSettings("test_app", local_file=True, flat_config=True)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -309,8 +309,10 @@ schema_version= '1'
         """Test that mutually exclusive attributes are handled."""
         fs.create_dir(Path.home())
 
-        with pytest.raises(
-            SettingsMutuallyExclusiveError,
-            match="Only one of flat_config, local_file can be True.",
-        ):
+        error_pattern = (
+            r"Only one of (flat_config|local_file), "
+            r"(flat_config|local_file) can be True\."
+        )
+
+        with pytest.raises(SettingsMutuallyExclusiveError, match=error_pattern):
             CustomSettings("test_app", local_file=True, flat_config=True)


### PR DESCRIPTION
For now the mutually-exclusive options are `local_file`, `flat_config` and `xdg_config`.

If two or more of these are used the library will raise a `SettingsMutuallyExclusiveError`