### PR TITLE
add 'allow_missing_file' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The below is a minimal example, for full documentation and information on
 available options, see the [documentation
 site](https://seapagan.github.io/simple-toml-settings/). There are several flags
 you can set to change the location of the settings file, the name of the file,
-and more.
+allowing to run without a settings file, and more.
 
 Usage is simple:
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,9 +12,6 @@
 - By default `save()` should not save config options that are not already in the
   config file, though leave the current behavior as an option.
 - Raise a specific custom exception for malformed TOML files
-- Option to NOT create a config file if it does not exist, but also NOT raise an
-  exception. This allows just using the default values set in the class, but
-  still take from the config file if it exists.
 
 ## Possible ideas
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,10 @@ A Python library to save your settings in a TOML file.
 - By default the setting file is automatically created when the class is
   instantiated and the settings are saved to it. If the file already exists, the
   settings are loaded from it instead. This can be disabled if required.
+- Allows to run WITHOUT a settings file, so you can use the settings class
+  without needing to save the settings. This way all the defaults are used, and
+  then the user can manually create the settings file if they want to change the
+  defaults.
 - The settings filename is configurable or defaults to `config.toml`.
 - Provides a hook to run code when the setting file is first created, so you can
   perform any initialisation required.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -229,12 +229,30 @@ file does not exist. You can catch this exception and handle it as you wish.
 *The folder will be created anyway if it does not exist, as the assumption is
 that you will want to save the settings at some point*.
 
+**This setting will be set to `False` if the `allow_missing_file` option is set
+to `True`.**
+
 !!! danger "Deprecation warning"
 
     The exception was originally called **`SettingsNotFound`** but has been
     renamed to **`SettingsNotFoundError`** to be more consistent with Python
     naming conventions.  The old name still works, but will be removed in a
     future release.
+
+### `allow_missing_file`
+
+This defaults to `False` and will allow the class to run without a settings
+file. This means that no error will be raised for a missing settings file, and
+the settings will always be the default values until a settings file is created.
+The user can then manually create the settings file if they want to change the
+defaults.
+
+This should really be the default setting, but for backwards compatibility it
+is set to `False` by default.  In future versions this may be changed.
+
+!!! note
+    Setting this to `True` will disable the `auto_create` option, as there is no
+    need to create the file if it is allowed to be missing.
 
 ### `local_file`
 

--- a/simple_toml_settings/settings.py
+++ b/simple_toml_settings/settings.py
@@ -37,6 +37,7 @@ class TOMLSettings:
     local_file: bool = False
     flat_config: bool = False
     xdg_config: bool = False
+    allow_missing_file: bool = False
 
     # the schema_version is used to track changes to the settings file.
     schema_version: str = "none"
@@ -53,6 +54,7 @@ class TOMLSettings:
             "local_file",
             "flat_config",
             "xdg_config",
+            "allow_missing_file",
         }
     )
 
@@ -155,6 +157,8 @@ class TOMLSettings:
             if self.auto_create:
                 self.__post_create_hook__()
                 self.save()
+            elif self.allow_missing_file:
+                return
             else:
                 message = "Cant find a Config File, please create one."
                 raise SettingsNotFoundError(message) from exc

--- a/simple_toml_settings/settings.py
+++ b/simple_toml_settings/settings.py
@@ -66,6 +66,10 @@ class TOMLSettings:
         """Create the settings folder if it doesn't exist."""
         self.settings_folder = self.get_settings_folder()
 
+        # if we allow a missing file, we don't want to auto-create it
+        if self.allow_missing_file:
+            self.auto_create = False
+
         # ensure only one of the mutually exclusive options is set
         check_exclusive = {
             attr for attr in self._mutually_exclusive if getattr(self, attr)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -56,10 +56,14 @@ schema_version= '1'
     def test_no_exception_raised_on_missing_config_if_allow_no_file_is_true(
         self, fs: FakeFilesystem
     ) -> None:
-        """Test that the settings file is not created if auto_create False."""
+        """Test the 'allow_missing_file' option.
+
+        If 'allow_missing_file' is True, and 'auto_create' is False, then the
+        settings file is not created, and no exception is raised.
+        """
         fs.create_dir(Path.home())
 
-        settings = TOMLSettings(
+        settings = CustomSettings(
             "test_app", auto_create=False, allow_missing_file=True
         )
         assert settings.settings_folder.exists()
@@ -67,6 +71,10 @@ schema_version= '1'
         assert settings.settings_folder.name == f".{self.TEST_APP_NAME}"
         # assert that the config file is not created
         assert not (settings.settings_folder / self.SETTINGS_FILE_NAME).exists()
+
+        # make sure we can still get values from the settings object
+        assert settings.get("app_name") == "test_app"
+        assert settings.get("my_var") is False
 
     def test_local_config(self, fs: FakeFilesystem) -> None:
         """Test that local_config loads settings from the local directory."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -53,6 +53,22 @@ schema_version= '1'
         with pytest.raises(SettingsNotFoundError):
             TOMLSettings("test_app", auto_create=False)
 
+    def test_allow_missing_file_disables_auto_create(
+        self, fs: FakeFilesystem
+    ) -> None:
+        """Test that allow_missing_file disables auto_create."""
+        fs.create_dir(Path.home())
+        settings = CustomSettings(
+            "test_app", auto_create=True, allow_missing_file=True
+        )
+        assert settings.settings_folder.exists()
+        assert settings.settings_folder.is_dir()
+        assert settings.settings_folder.name == f".{self.TEST_APP_NAME}"
+        # assert that the config file is not created
+        assert not (settings.settings_folder / self.SETTINGS_FILE_NAME).exists()
+        # assert that 'auto_create' is False
+        assert not settings.auto_create
+
     def test_no_exception_raised_on_missing_config_if_allow_no_file_is_true(
         self, fs: FakeFilesystem
     ) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -53,6 +53,21 @@ schema_version= '1'
         with pytest.raises(SettingsNotFoundError):
             TOMLSettings("test_app", auto_create=False)
 
+    def test_no_exception_raised_on_missing_config_if_allow_no_file_is_true(
+        self, fs: FakeFilesystem
+    ) -> None:
+        """Test that the settings file is not created if auto_create False."""
+        fs.create_dir(Path.home())
+
+        settings = TOMLSettings(
+            "test_app", auto_create=False, allow_missing_file=True
+        )
+        assert settings.settings_folder.exists()
+        assert settings.settings_folder.is_dir()
+        assert settings.settings_folder.name == f".{self.TEST_APP_NAME}"
+        # assert that the config file is not created
+        assert not (settings.settings_folder / self.SETTINGS_FILE_NAME).exists()
+
     def test_local_config(self, fs: FakeFilesystem) -> None:
         """Test that local_config loads settings from the local directory."""
         fs.create_file(


### PR DESCRIPTION
Allow running with a missing config file. This way, a project can run on defaults and user can provide the config if needed. Defaults to `False` for backwards compatibility.

option is `allow_missing_file`